### PR TITLE
Fix for OSX (rails image)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The rails base image includes a system for managing a non-root internal docker u
 
 ### Rails base image changelog
 
+#### Version 0.3
+
+* If the host user id is 0, skip the host user sync step. This probably means the host enviornment is OSX, where it doesn't matter if the container user and host user are synced.
+
 #### Version 0.2
 
 * The dockerfile now creates a non-root user (named "docker") and runs as that user

--- a/rails/entrypoint_scripts/sync_docker_user_with_host_user.sh
+++ b/rails/entrypoint_scripts/sync_docker_user_with_host_user.sh
@@ -6,7 +6,7 @@ HOST_UID=$(stat -c %u /home/docker/app)
 HOST_GID=$(stat -c %g /home/docker/app)
 
 # If the docker user doesn't share the same uid, change it so that it does
-if [ ! "${HOST_UID}" = "$(id -u docker)" ]; then
+if [ ! "${HOST_UID}" = "$(id -u docker)" ] && [ ! "${HOST_UID}" = "0" ]; then
   usermod -u $HOST_UID docker
   groupmod -g $HOST_GID docker
 


### PR DESCRIPTION
## Purpose

For OSX users, the host user id returned by docker is `0`, which breaks the attempt to sync the container uid with the host uid. So this PR works around it by just skipping the sync step for OSX, leaving the uid/gid at the original of 9999/9999.

For OSX, it doesn't matter if the uids are synced, because files created in a container on macs always end up with the host user as owner anyway.

## Risk factors

No risk. Worst that can happen is it doesn't work, which it already doesn't.

## Launch plan

Merge when approved. Then tag and relase version rails-0.3.