### PR TITLE
Docker exec with gosu instead of sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The rails base image includes a system for managing a non-root internal docker u
 
 ### Rails base image changelog
 
+#### Version 0.4
+
+* Use "gosu" in the final entrypoint exec instead of "sudo".
+
 #### Version 0.3
 
 * If the host user id is 0, skip the host user sync step. This probably means the host enviornment is OSX, where it doesn't matter if the container user and host user are synced.

--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -8,16 +8,25 @@ RUN chmod +x /usr/local/bin/docker-ssh-exec
 ADD entrypoint_scripts /opt/entrypoint/
 RUN chmod -R +x /opt/entrypoint/*
 
+# Install wget, vim, suo
+RUN apt-get update \
+  && apt-get install -y wget vim sudo \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install gosu
+RUN GOSU_VERSION=1.10 \
+  && DPKG_ARCH="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
+  && DOWNLOAD_URL="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${DPKG_ARCH}" \
+  && wget -O /usr/local/bin/gosu $DOWNLOAD_URL \
+  && chmod +x /usr/local/bin/gosu
+
 # Create a non-root user "docker" to run as, with an arbitrary uid/gid
 # The entrypoint will be responsible for later setting the uid/gid to match the host's
 RUN \
   groupadd -f -g 9999 docker \
-  && useradd --shell /bin/bash -u 9999 -g 9999 -m docker
-
-# Also make the user a sudoer
-RUN \
-  apt-get update && apt-get install -y sudo vim \
-  && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && useradd --shell /bin/bash -u 9999 -g 9999 -m docker \
+  # Also make the user a sudoer
   && echo "docker ALL=(ALL) NOPASSWD:SETENV:ALL" >> "/etc/sudoers" \
   && echo "Defaults always_set_home" >> "/etc/sudoers"
 

--- a/rails/entrypoint_scripts/exec_as_docker_user.sh
+++ b/rails/entrypoint_scripts/exec_as_docker_user.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-exec sudo -E -u docker PATH=$BUNDLE_BIN:$PATH docker-ssh-exec $@
+exec gosu docker docker-ssh-exec $@


### PR DESCRIPTION
## Purpose

This adds rails base image version 0.4, which is basically the same as 0.3 except the final exec line uses "gosu" instead of "sudo". I potential fix for OSX where the sudo command didn't seem to be working right.

### Risk factors

No risk, worst case it doesn't work.

### Launch plan

Merge, then build, tag, and release version rails-0.4.
