### PR TITLE
start-docker-ssh-exec

### DIFF
--- a/bin/start-docker-ssh-exec
+++ b/bin/start-docker-ssh-exec
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Start the docker-ssh-container if not already started
+if docker top docker-ssh-exec &>/dev/null; then
+  echo "docker-ssh-exec server is already running"
+else
+  echo "starting docker-ssh-exec server"
+
+  echo -n "ssh passphrase (leave blank for none): "
+  read -s ssh_passphrase
+  echo
+
+  # In case the image is not yet downloaded, silently pull it
+  docker pull mdsol/docker-ssh-exec &> /dev/null
+  # In case a previous stopped container exists, silently remove it
+  docker rm docker-ssh-exec &> /dev/null
+
+  if [[ ! -z $ssh_passphrase ]]; then
+    passphrase_cli_arg="-pwd $ssh_passphrase"
+  fi
+
+  # Start docker-ssh-exec (with passphrase, if supplied)
+  docker run \
+    --restart always \
+    -v ~/.ssh/id_rsa:/root/.ssh/id_rsa \
+    --name=docker-ssh-exec \
+    -d mdsol/docker-ssh-exec \
+    -server \
+    $passphrase_cli_arg \
+    &> /dev/null
+
+  echo "container started"
+fi
+
+# Create the network if it does not already exist
+if docker network inspect docker-ssh-exec &>/dev/null; then
+  echo "docker-ssh-exec network already exists"
+else
+  docker network create docker-ssh-exec &> /dev/null
+  echo "docker-ssh-exec network created"
+fi
+
+# Connect to the network if it's not already connected
+if [[ $(docker inspect docker-ssh-exec -f '{{.NetworkSettings.Networks}}') =~ docker-ssh-exec ]]; then
+  echo "container is already connected to the network"
+else
+  docker network connect docker-ssh-exec docker-ssh-exec
+  echo "container connected to network"
+fi
+
+echo "docker-ssh-exec is ready"

--- a/bin/start-docker-ssh-exec
+++ b/bin/start-docker-ssh-exec
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Start the docker-ssh-container if not already started
-if docker top docker-ssh-exec &>/dev/null; then
+if docker top docker-ssh-exec &> /dev/null; then
   echo "docker-ssh-exec server is already running"
 else
   echo "starting docker-ssh-exec server"
@@ -33,7 +33,7 @@ else
 fi
 
 # Create the network if it does not already exist
-if docker network inspect docker-ssh-exec &>/dev/null; then
+if docker network inspect docker-ssh-exec &> /dev/null; then
   echo "docker-ssh-exec network already exists"
 else
   docker network create docker-ssh-exec &> /dev/null


### PR DESCRIPTION
### Purpose

This adds a script to start the docker-ssh-exec key server container and add it to its own dedicated network. The idea is that we'll update the docker-compose files on various repos to remove the `ssh` service, and instead connect to this docker-ssh-exec network for access to a single running key server container.

And then we'll have people directly curl and run this script to start that container and connect it to the network. i.e. This is the command people will have to run once:

    bash <(curl -s https://raw.githubusercontent.com/voxmedia/docker_base_images/master/bin/start-docker-ssh-exec)

### Tests and risks

This was verified locally to work. Tested it under various states of the container/network existing/started/connected and it seems to work under all circumstances.

### Launch plan

After merging, update all the repos to use this new network, update docs, and make an engineering announcement about the change in docker workflow.