### PR TITLE
Add a new `!docker-ssh-exec` network

### DIFF
--- a/bin/start-docker-ssh-exec
+++ b/bin/start-docker-ssh-exec
@@ -33,19 +33,37 @@ docker run \
 echo "container started"
 
 # Create the network if it does not already exist
-if docker network inspect docker-ssh-exec &> /dev/null; then
+if docker network inspect \!docker-ssh-exec &> /dev/null; then
   echo "docker-ssh-exec network already exists"
 else
-  docker network create docker-ssh-exec &> /dev/null
+  docker network create \!docker-ssh-exec &> /dev/null
   echo "docker-ssh-exec network created"
 fi
 
 # Connect to the network if it's not already connected
-if [[ $(docker inspect docker-ssh-exec -f '{{.NetworkSettings.Networks}}') =~ docker-ssh-exec ]]; then
+if [[ $(docker inspect docker-ssh-exec -f '{{.NetworkSettings.Networks}}') =~ !docker-ssh-exec ]]; then
   echo "container is already connected to the network"
 else
-  docker network connect docker-ssh-exec docker-ssh-exec
+  docker network connect \!docker-ssh-exec docker-ssh-exec
   echo "container connected to network"
+fi
+
+# Create the network if it does not already exist
+# TODO: remove once all apps have switched over to new network above
+if docker network inspect docker-ssh-exec &> /dev/null; then
+  echo "legacy docker-ssh-exec network already exists"
+else
+  docker network create docker-ssh-exec &> /dev/null
+  echo "legacy docker-ssh-exec network created"
+fi
+
+# Connect to the network if it's not already connected
+# TODO: remove once all apps have switched over to new network above
+if [[ $(docker inspect docker-ssh-exec -f '{{.NetworkSettings.Networks}}') =~ [^!]docker-ssh-exec ]]; then
+  echo "container is already connected to the legacy network"
+else
+  docker network connect docker-ssh-exec docker-ssh-exec
+  echo "container connected to legacy network"
 fi
 
 echo "docker-ssh-exec is ready"


### PR DESCRIPTION
The `docker-ssh-exec` client works by [broadcasting to multicast address `255.255.255.255`](https://github.com/mdsol/docker-ssh-exec/blob/master/client.go#L21), which in docker maps to the `eth0` interface. This means that the `docker-ssh-exec` server must be listening on the `eth0` network interface in order to see the client broadcast.

And in docker, If a container is connected to multiple networks, each one gets its own network interface, starting with `eth0` and incrementing for subsequent network connections. So in order to get the key server to listen on eth0, it must be the first network a container is connected to.

The way docker-compose works, if you specify multiple networks, it connects to them in alphabetical order (keyed on network name). Thus, in order to ensure the key server network is connected first, its network name must be sorted higher in alphabetical order.

So this PR adds a new network `!docker-ssh-exec`. The `!` ensures it will always be ranked highest in the list of networks, and thus always connected to eth0 via docker-compose.

The legacy `docker-ssh-exec` network is also still being created here, for compatibility with apps that are referencing it, but this legacy network will be removed as soon as all the apps referencing it are updated to reference the new network.
