### PR TITLE
Emit an error if files not owned by user

### DIFF
--- a/bin/start-docker-ssh-exec
+++ b/bin/start-docker-ssh-exec
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 # Verify we're the owner of all files in this repo
-GIT_TOP_LEVEL="$(git rev-parse --show-toplevel 2> /dev/null)"
-if [ "$GIT_TOP_LEVEL" == "" ]; then
+git_top_level="$(git rev-parse --show-toplevel 2> /dev/null)"
+if [ "$git_top_level" == "" ]; then
   echo "Error: Not in a git repo"
   exit 1
 fi
 WHOAMI="$(whoami)"
-if [[ $(find $GIT_TOP_LEVEL -nouser -or -not -user $WHOAMI) ]]; then
+if [[ $(find $git_top_level -nouser -or -not -user $WHOAMI) ]]; then
   echo "Error: There are files in this repo that are not owned by $WHOAMI. This can"
   echo "cause docker-sync to behave badly, so you'll want to re-chown your files."
-  echo "You can find those files with: find $GIT_TOP_LEVEL -nouser -or -not -user $WHOAMI"
+  echo "You can find those files with: find $git_top_level -nouser -or -not -user $WHOAMI"
   exit 1
 fi
 

--- a/bin/start-docker-ssh-exec
+++ b/bin/start-docker-ssh-exec
@@ -2,16 +2,15 @@
 
 # Verify we're the owner of all files in this repo
 git_top_level="$(git rev-parse --show-toplevel 2> /dev/null)"
-if [ "$git_top_level" == "" ]; then
-  echo "Error: Not in a git repo"
-  exit 1
-fi
-WHOAMI="$(whoami)"
-if [[ $(find $git_top_level -nouser -or -not -user $WHOAMI) ]]; then
-  echo "Error: There are files in this repo that are not owned by $WHOAMI. This can"
-  echo "cause docker-sync to behave badly, so you'll want to re-chown your files."
-  echo "You can find those files with: find $git_top_level -nouser -or -not -user $WHOAMI"
-  exit 1
+if [ "$git_top_level" != "" ]; then
+  whoami="$(whoami)"
+  if [[ $(find $git_top_level -nouser -or -not -user $whoami) ]]; then
+    echo "Error: You're in a repo with files that are not owned by $whoami. This can"
+    echo "cause docker-sync to behave badly, so you'll almost certainly want to"
+    echo "re-chown your files. You can find those files with:"
+    echo "find $git_top_level -nouser -or -not -user $whoami"
+    exit 1
+  fi
 fi
 
 # Start the docker-ssh-container if not already started

--- a/bin/start-docker-ssh-exec
+++ b/bin/start-docker-ssh-exec
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Verify we're the owner of all files in this repo
+GIT_TOP_LEVEL="$(git rev-parse --show-toplevel 2> /dev/null)"
+if [ "$GIT_TOP_LEVEL" == "" ]; then
+  echo "Error: Not in a git repo"
+  exit 1
+fi
+WHOAMI="$(whoami)"
+if [[ $(find $GIT_TOP_LEVEL -nouser -or -not -user $WHOAMI) ]]; then
+  echo "Error: There are files in this repo that are not owned by $WHOAMI. This can"
+  echo "cause docker-sync to behave badly, so you'll want to re-chown your files."
+  echo "You can find those files with: find $GIT_TOP_LEVEL -nouser -or -not -user $WHOAMI"
+  exit 1
+fi
+
 # Start the docker-ssh-container if not already started
 if docker inspect docker-ssh-exec &> /dev/null; then
   echo "old (likely stale) docker-ssh-exec server found, removing"


### PR DESCRIPTION
### Purpose

Yesterday Ben lost 3 hours to a docker-sync problem, finally solving it and reporting:

> oh my god, docker-sync totally screwed up the ownership of my sbn files. half of them are owned by root now, and all of them have the root group now...no wonder things are messing up. apparently this error message ` Couldn't connect to Docker daemon at http+docker://localunixsocket - is it running?` can mean like 30 different things and i finally stumbled upon someone pointing out file permissions issues on a mounted volume

This PR institutionalizes that wisdom. Hopefully the next person won't lose 3 hours.

(Under most circumstances, having development files' group set to `root` has little practical effect, so this doesn't check for that, even though it would be pretty unusual and probably technically incorrect. My guess is that docker-sync won't malfunction if that were the only thing wrong.)

### Caveat

I recognize that this script's ostensible purpose is setup for the docker-ssh-exec script, not prep work for docker-sync. But in [our instructions](https://github.com/voxmedia/sbn/wiki/Chorus-on-Docker#tldr-setup) running this script comes right before docker-sync. So it's a great place to shoehorn in sanity checking.

IMHO we should be thinking about expanding this script to be a general-purpose "set up a repo for docker-compose." And not just that, but also incorporating the next two instructions into it as well, to simplify our instructions for our developers. I.e., is there any reason this script couldn't also do the

```
gem install docker-sync
# (docker-sync stop, then)
docker-sync start
```

commands that Chorus requires? Maybe the `sbn` repo could indicate that those commands are part of its setup somehow, so that this script knows to trigger them?

### Risks

I'm pretty sure this will blow up if there's a space in any directory leading up to the root of the git repo. Does anybody actually do that? God I hate shell scripting.