### PR TITLE
Script to force the syncing of docker time to the hosts time

### DIFF
--- a/bin/sync-docker-to-hwclock
+++ b/bin/sync-docker-to-hwclock
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+echo "
+This script will update the host crontab to force the syncing
+of the docker service clock to the host clock by adding the line
+
+* * * * * /usr/local/bin/docker run --rm --privileged alpine hwclock -s
+"
+
+# Check if the entry already exists in the crontab
+if sudo crontab -l | grep -q "/usr/local/bin/docker run --rm --privileged alpine hwclock -s"; then
+  echo "
+    An existing entry in crontab was found -- nothing to do.
+  "
+else
+  # add the line to the crontab
+  sudo crontab <<EOF
+  * * * * * /usr/local/bin/docker run --rm --privileged alpine hwclock -s
+EOF
+
+  echo "
+    crontab was updated successfully.
+  "
+fi


### PR DESCRIPTION
## Purpose

Some among us are experiencing issues with [time drift between the host and the containers on Mac OS X](https://github.com/docker/for-mac/issues/2076#issuecomment-375455684).

One of the symptoms of this issue are changes to code made on the host are not being reflected in the container in a timely fashion and containers continue to executed the old code even though the source files in the container reflect the changes made on the host.

After some investigations (thanks @thomsbg), the issue appears to be caused by the clock used by the docker service drifting out of sync with the host.

The suggested solution is to add a job to the `crontab` that forces the clock used by docker to sync with the host's hardware clock.

To setup the job, users would
```
bash <(curl -s https://raw.githubusercontent.com/voxmedia/docker_base_images/master/bin/sync-docker-to-hwclock)
```

## Notables

This script injects the job into `root`s crontab:
```
* * * * * /usr/local/bin/docker run --rm --privileged alpine hwclock -s
```
if it doesn't already exist. This job runs every minute and is the current workaround suggested in the github issue linked above.

## Tests & Risks

This has been tested locally and only adds one instance of the job. The risk is low.

## Gif (cron)

![lisa simpson](https://media.giphy.com/media/C1t2dRoGBYZyw/giphy.gif)