### PR TITLE
Push all images to both portus and dockerhub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,8 @@ def lint(image) {
 }
 
 def rubyDockerBuildAndPush(rubyVersion, branch) {
-  def buildArgs = "--build-arg RUBY_VERSION=${rubyVersion} --build-arg LIBMYSQLCLIENT=default-libmysqlclient-dev"
+  def libmysqlclient = rubyVersion == '2.2' ? 'libmysqlclient-dev' : 'default-libmysqlclient-dev'
+  def buildArgs = "--build-arg RUBY_VERSION=${rubyVersion} --build-arg LIBMYSQLCLIENT=${libmysqlclient}"
   dockerBuildAndPush('ruby', branch, buildArgs, "${rubyVersion}-")
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,8 +5,7 @@ def lint(image) {
 }
 
 def rubyDockerBuildAndPush(rubyVersion, branch) {
-  def libmysqlclient = rubyVersion == '2.5' ? 'default-libmysqlclient-dev' : 'libmysqlclient-dev'
-  def buildArgs = "--build-arg RUBY_VERSION=${rubyVersion} --build-arg LIBMYSQLCLIENT=${libmysqlclient}"
+  def buildArgs = "--build-arg RUBY_VERSION=${rubyVersion} --build-arg LIBMYSQLCLIENT=default-libmysqlclient-dev"
   dockerBuildAndPush('ruby', branch, buildArgs, "${rubyVersion}-")
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,9 +12,15 @@ def rubyDockerBuildAndPush(rubyVersion, branch) {
 
 def dockerBuildAndPush(image, branch, buildArgs = '', versionPrefix = '') {
   def version = sh(returnStdout: true, script: "cat ${image}/VERSION").trim()
-  def tag = "docker.voxops.net/${image}:${versionPrefix}${version}"
-  sh "docker build ${image} ${buildArgs} -t ${tag}"
-  if (branch == 'master') { sh "docker push ${tag}" }
+
+  def localTag = "${image}:${versionPrefix}${version}"
+  sh "docker build ${image} ${buildArgs} -t ${localTag}"
+
+  ['docker.voxops.net', 'voxmedia'].each {
+    def registryTag = "${it}/${localTag}"
+    sh "docker tag ${localTag} ${registryTag}"
+    if (branch == 'master') { sh "docker push ${registryTag}" }
+  }
 }
 
 pipeline {


### PR DESCRIPTION
## Purpose

Portus requires the vpn, and packer sandboxes do not have vpn access. So the full move to portus was premature. This PR adds back pushing to dockerhub (while continuing to also push to portus) until we have a better solution or decommission packer sandboxes.