### PR TITLE
Fix typo in wait_for_node_install.sh script

### DIFF
--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Ruby images changelog
 
+#### Version ruby:2.x-3.x.x
+
+* Fixed typo in `wait_for_node_install.sh`
+
 #### Version ruby:2.x-3.0.3
 
 * Deprecates Ruby 2.2

--- a/ruby/entrypoint_scripts/wait_for_node_install.sh
+++ b/ruby/entrypoint_scripts/wait_for_node_install.sh
@@ -5,7 +5,7 @@ ITERATIONS=${WAIT_FOR_NODE:-60}
 NODE_READY=false
 
 for i in $(seq 1 $ITERATIONS); do
-  if yarn bin > /dev/null 2&>1; then
+  if yarn bin > /dev/null 2>&1; then
     yarn check > /dev/null
   else
     npm ls --no-progress > /dev/null 2>&1


### PR DESCRIPTION
This fixes a typo that was causing a file named `1` to appear with the contents `error Couldn't find a binary named "2"`. I traced this back to the `wait_for_node_install.sh` script which had `2&>1` instead of `2>&1`.